### PR TITLE
Remove weird trailing comma in block

### DIFF
--- a/src/QuadraticFormsMGHyp.jl
+++ b/src/QuadraticFormsMGHyp.jl
@@ -169,7 +169,7 @@ function get_funcs(omega, de, e2, d2, c, k, LK2, lam, chi, psi)
                               lklam(lam + j,
                                         chi - 2 * (0.5 * s^2 * t1 + t),
                                         psi - 2 * (k * s + 0.5 * s^2 * t2),
-                                        ) - LK2 + s * c + s^2 * t3 + 0.5 * t4,
+                                        ) - LK2 + s * c + s^2 * t3 + 0.5 * t4
                                     )
     lM(s, t) = logTheta(s, t, 0)
     lM0(s, t) = logTheta(s, t, 1)


### PR DESCRIPTION
Found as part of testing for JuliaLang/julia#46372 - JuliaSyntax.jl considers the trailing comma in `(a; b,)` to imply a "frakentuple" for consistency with the way `(a; b, c)` parses.  However the reference parser just ignores this trailing comma and parses `(a; b,)` inconsistently with `(a; b, c)`.

Congratulations, this is the only project in the General registry which found this weird syntax edge case :sweat_smile: 